### PR TITLE
Fix 'unexpected operator' issue

### DIFF
--- a/git-rewrite-author
+++ b/git-rewrite-author
@@ -47,7 +47,7 @@ Example:
 $ git-rewrite-author -w "Name <me@localhost>" "Full Name <me@example.com>"
 """
 
-git_rewrite_command = """git filter-branch --env-filter 'if [ "$GIT_AUTHOR_NAME" == "%s" -a "$GIT_AUTHOR_EMAIL" == "%s" ]; then GIT_AUTHOR_NAME="%s"; GIT_AUTHOR_EMAIL="%s"; fi; export GIT_AUTHOR_NAME; export GIT_AUTHOR_EMAIL' --tag-name-filter cat -f -- --all"""
+git_rewrite_command = """git filter-branch --env-filter 'if [ "$GIT_AUTHOR_NAME" = "%s" -a "$GIT_AUTHOR_EMAIL" = "%s" ]; then GIT_AUTHOR_NAME="%s"; GIT_AUTHOR_EMAIL="%s"; fi; export GIT_AUTHOR_NAME; export GIT_AUTHOR_EMAIL' --tag-name-filter cat -f -- --all"""
 git_log_command = "git log --pretty=full"
 
 


### PR DESCRIPTION
For some reason when using == for string comparison leads to the following error on my Ubuntu 13.04:

Rewrite 3a5437f0df459d86b66b42892a87bbb262acef72 (1/16)/usr/lib/git-core/git-filter-branch: 1: [: Kaloyan Raev: unexpected operator

Replacing == with = resolved the issue.
