### PR TITLE
Documenting force push usage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,10 @@ Usage::
 
     $ git-rewrite-author -w "John Doe <john@localhost>" "John Doe <dearjohn@example.com>"
 
+    $ git push --force
+
+Not using --force will duplicate the commits on origin, not replace them, so be careful with that.
+
 You're not sure which authors/committers are hidden in your repository?
 What about::
 


### PR DESCRIPTION
Not using git push --force will duplicate the commits in the origin. Because this lead to some trouble on my end when using the tool, I believe it should be added to the README file.

It's kind of obvious when you think about how git + github works but still think it should be documented for the less experienced users or for those in a rush (like me).